### PR TITLE
Save model after building vocab

### DIFF
--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -15,6 +15,12 @@ class EpochSaver(CallbackAny2Vec):
         self.directory = directory
         self.frequency = frequency
 
+    def on_train_begin(self, model: Word2Vec):
+        # Save the model at the beginning of training (after it has compiled)
+        # the vocabulary so that we don't have to load in the vocabulary if we
+        # want to start training again on the same dataset.
+        model.save(os.path.join(self.directory, "start.model"))
+
     def on_epoch_begin(self, model: Word2Vec):
         self.epoch += 1
 


### PR DESCRIPTION
Ensure that the model is saved after we have the model build the vocab (right before training starts).

This will allow us to really only build the vocabulary once per dataset as we can simply reload this starting model every time we want to train another model on the dataset.