### PR TITLE
add arguements for table, column, and number of rows

### DIFF
--- a/src/data/malamud_dataset.py
+++ b/src/data/malamud_dataset.py
@@ -3,10 +3,8 @@ import itertools
 import pandas as pd
 from streampq import streampq_connect
 
-PG_QUERY = "SELECT * FROM docs.doc_ngrams_0"
-
 class MalamudDataset:
-    """
+    """Iterator class for loading malamud general index data from a postgres database
     
     Attributes:
         postgres_conn_params: Tuple of tuples, each containing a key value pair with postgres connection details
@@ -19,15 +17,21 @@ class MalamudDataset:
                     ('password', 'my_password'),
                 )
         chunk_size: Integer indicating the number of rows in each dataframe chunk
+        table: String indicating table to use within the malamud database
+        column: String indicating column to use within the selected table
+        rows: Number of rows to train with, starting from 0
     """
-    def __init__(self, postgres_conn_params: tuple, chunk_size: int=10000):
+    def __init__(self, postgres_conn_params: tuple, chunk_size: int, table: str, column: str, rows: int=None):
         self.postgres_conn_params = postgres_conn_params
         self.chunk_size = chunk_size
+        self.table = table
+        self.column = column
+        self.pg_command = f"SELECT * FROM {self.table}{f' limit {rows}' if rows != float('inf') else ''}"
 
     def __iter__(self):
         conn = streampq_connect(self.postgres_conn_params)
         with conn as query:
-            for chunked_dfs in self.query_chunked_dfs(query, PG_QUERY, chunk_size=self.chunk_size):  # TODO: Experiment with different chunk sizes
+            for chunked_dfs in self.query_chunked_dfs(query, self.pg_command, chunk_size=self.chunk_size):  # TODO: Experiment with different chunk sizes
                 for df in chunked_dfs:
                     for ngram in df:
                         yield ngram
@@ -38,7 +42,7 @@ class MalamudDataset:
         def _chunked_df(columns, rows):
             it = iter(rows)
             while True:
-                df = pd.DataFrame(itertools.islice(it, chunk_size), columns=columns).ngram_lc.apply(gensim.utils.simple_preprocess)
+                df = pd.DataFrame(itertools.islice(it, chunk_size), columns=columns)[self.column].apply(gensim.utils.simple_preprocess)
                 if len(df) == 0:
                     break
                 yield df

--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,13 @@ def main(args):
     if args.test:
         epoch_logger = EpochLogger()
         epoch_saver = EpochSaver(args.directory, frequency=1)
-        dataset = MalamudDataset(postgres_conn_params=POSTGRES_CONNECTION, chunk_size=args.chunk_size)
+        dataset = MalamudDataset(
+            postgres_conn_params=POSTGRES_CONNECTION,
+            chunk_size=args.chunk_size,
+            table=args.table,
+            column=args.column,
+            rows=args.rows
+        )
         # dataset = AmazonDataset("./amazon_product_reviews.json")
         # dataset = LineSentence("./test_dataset.txt")  # For if you want to try an extremely small dataset.
         model = MalamudWord2Vec(workers=args.workers,
@@ -65,6 +71,9 @@ if __name__ == "__main__":
     parser.add_argument("--epochs", type=int, required=True)
     parser.add_argument("--vector_size", type=int, required=True)
     parser.add_argument("--chunk_size", type=int, default=100000)
+    parser.add_argument("--table", type=str, default='docs.doc_ngrams_0')
+    parser.add_argument("--column", type=str, default='ngram_lc')
+    parser.add_argument("--rows", type=int, default=float('inf')),
     parser.add_argument("--test", action="store_true")  # Used for testing.
     args = parser.parse_args()
 


### PR DESCRIPTION
Allows us to train on the keywords table (or others), and specify how many rows from the specified table it should use